### PR TITLE
Fixed bug with truncated archived failing testcase

### DIFF
--- a/fuzzer.py
+++ b/fuzzer.py
@@ -255,6 +255,7 @@ class OpenH264(Fuzzer):
       fuzzed_buffer = self.mutate(sample_buffer)
       testcase = tempfile.NamedTemporaryFile()
       testcase.write(fuzzed_buffer)
+      testcase.flush()
       yuv = tempfile.NamedTemporaryFile()
       p = subprocess.Popen([self.decbin, testcase.name, yuv.name],
                            stdout=subprocess.PIPE, 


### PR DESCRIPTION
The shutil.copy of testcase to an archive "testcase.264" in bucket resulted in truncated files.
The "testcase" file is still open (with buffered and un-flushed writes) at the time of the shutil.copy.
The fix is to testcase.flush() after the write() and before the copy.